### PR TITLE
Re-introduced the WGS84 bug for Albers (for BRIDGE use only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-## ESPA-PRODUCT_FORMATTER Version 1.13.1 Release Notes
-Release Date: August 2017
+## ESPA-PRODUCT_FORMATTER Version 1.13.2.b Release Notes
+Release Date: October 2017 (BRIDGE only)
 
 The product formatter project contains libraries and tools for working with the ESPA internal file format (raw binary with an XML metadata file). It currently supports Landsat 4-8.
 
@@ -10,7 +10,7 @@ espa-product-formatter source code
 
     git clone https://github.com/USGS-EROS/espa-product-formatter.git
 
-See git tag [version_1.13.1]
+See git tag [version_1.13.2.b]
 
 ### Dependencies
   * GCTP libraries (obtained from the GCTP directory in the HDF-EOS2 source code)
@@ -105,6 +105,9 @@ be needed for your application or other espa product formatter libraries may nee
 
 
 ## Release Notes
-  * Changed the print statements for the semi-major axis, semi-minor axis, and
+  * Reintroduced this bug which was fixed in v1.13.1 so that processing L8 ARD
+    Tiles will be consistent with existing L4-7 ARD Tiles which already have
+    the rounded (incorrect) WGS84 semi-major and -minor axes.
+    - Changed the print statements for the semi-major axis, semi-minor axis, and
     inverse flattening parameters.  The %g is truncating the semi-major axis
     for the Albers projection.

--- a/raw_binary/common/espa_common.h
+++ b/raw_binary/common/espa_common.h
@@ -14,7 +14,7 @@ NOTES:
 #ifndef ESPA_COMMON_H_
 #define ESPA_COMMON_H_
 
-#define ESPA_COMMON_VERSION "1.13.1"
+#define ESPA_COMMON_VERSION "1.13.2.b"
 
 /* Set up default success/error defines */
 #define SUCCESS 0

--- a/raw_binary/io_libs/envi_header.c
+++ b/raw_binary/io_libs/envi_header.c
@@ -161,7 +161,7 @@ int write_envi_hdr
             hdr->pixel_size[1], proj_datum_str);
         fprintf (hdr_fptr,
             "coordinate system string = GEOGCS[\"%s\", DATUM[\"%s\", "
-            "SPHEROID[\"%s\",%.11g,%.12g]], PRIMEM[\"Greenwich\",0.0], "
+            "SPHEROID[\"%s\",%g,%g]], PRIMEM[\"Greenwich\",0.0], "
             "UNIT[\"Degree\",0.0174532925199433]]\n", geogcs_str, datum_str,
             spheroid_str, semi_major_axis, inv_flattening);
     }
@@ -188,7 +188,7 @@ int write_envi_hdr
             hdr->ul_corner[0], hdr->ul_corner[1], hdr->pixel_size[0],
             hdr->pixel_size[1], proj_datum_str);
         fprintf (hdr_fptr,
-            "projection info = {%d, %.11g, %.11g, %g, %g, %g, %g, %g, %g, "
+            "projection info = {%d, %g, %g, %g, %g, %g, %g, %g, %g, "
             "%s, Albers Conical Equal Area, units=Meters}\n",
             ENVI_ALBERS_PROJ, semi_major_axis, semi_minor_axis,
             hdr->proj_parms[5], hdr->proj_parms[4], hdr->proj_parms[6],
@@ -197,7 +197,7 @@ int write_envi_hdr
         fprintf (hdr_fptr,
             "coordinate system string = "
             "{PROJCS[\"Albers\",GEOGCS[\"%s\", DATUM[\"%s\", "
-            "SPHEROID[\"%s\",%.11g,%.12g]], PRIMEM[\"Greenwich\",0.0], "
+            "SPHEROID[\"%s\",%g,%g]], PRIMEM[\"Greenwich\",0.0], "
             "UNIT[\"Degree\",0.0174532925199433]], "
             "PROJECTION[\"Albers\"], PARAMETER[\"False_Easting\",%f], "
             "PARAMETER[\"False_Northing\",%f], "
@@ -226,7 +226,7 @@ int write_envi_hdr
         fprintf (hdr_fptr,
             "coordinate system string = "
             "{PROJCS[\"Stereographic_South_Pole\", "
-            "GEOGCS[\"%s\", DATUM[\"%s\", SPHEROID[\"%s\",%.11g,%.12g]], "
+            "GEOGCS[\"%s\", DATUM[\"%s\", SPHEROID[\"%s\",%g,%g]], "
             "PRIMEM[\"Greenwich\",0.0], UNIT[\"Degree\",0.0174532925199433]], "
             "PROJECTION[\"Stereographic_South_Pole\"], "
             "PARAMETER[\"False_Easting\",%f], "


### PR DESCRIPTION
Peer review for the re-introduction of the WGS84 semi-major and semi-minor bug being truncated due to writing it in the E+## format.