### PR TITLE
Dev v1.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,5 @@ be needed for your application or other espa product formatter libraries may nee
 ## Release Notes
   * Cleaned up some warning codes flagged after migrating to a newer system.
   * Fixed a bug in parse_sentinel_metadata.c.  Prodtype is a character
-    pointer and not an array, therefore the pointer must be dereferenced
-    when used as an argument in sizeof.
+    pointer and not an array, therefore using the size of the pointer is not
+    valid when used as an argument in sizeof.

--- a/README.md
+++ b/README.md
@@ -128,3 +128,5 @@ be needed for your application or other espa product formatter libraries may nee
   * Fixed a bug in parse_sentinel_metadata.c.  Prodtype is a character
     pointer and not an array, therefore using the size of the pointer is not
     valid when used as an argument in sizeof.
+  * Added a script for unpackaging the Sentinel-2 product bundles so they are
+    in the proper format for ingesting via convert_sentinel_to_espa.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-## ESPA-PRODUCT_FORMATTER Version 1.18.1 Release Notes
-Release Date: October 2019
+## ESPA-PRODUCT_FORMATTER Version 1.19.0 Release Notes
+Release Date: November 2019
 
 The product formatter project contains libraries and tools for working with the ESPA internal file format (raw binary with an XML metadata file). It currently supports Landsat 4-8.
 
@@ -14,7 +14,7 @@ espa-product-formatter source code
 
     git clone https://github.com/USGS-EROS/espa-product-formatter.git
 
-See git tag [version_1.18.1]
+See git tag [version_1.19.0]
 
 ### Dependencies
   * GCTP libraries (obtained from the GCTP directory in the HDF-EOS2 source code)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-## ESPA-PRODUCT_FORMATTER Version 1.18.0 Release Notes
-Release Date: July 2019
+## ESPA-PRODUCT_FORMATTER Version 1.18.1 Release Notes
+Release Date: October 2019
 
 The product formatter project contains libraries and tools for working with the ESPA internal file format (raw binary with an XML metadata file). It currently supports Landsat 4-8.
 
@@ -14,7 +14,7 @@ espa-product-formatter source code
 
     git clone https://github.com/USGS-EROS/espa-product-formatter.git
 
-See git tag [version_1.18.0]
+See git tag [version_1.18.1]
 
 ### Dependencies
   * GCTP libraries (obtained from the GCTP directory in the HDF-EOS2 source code)
@@ -124,18 +124,7 @@ be needed for your application or other espa product formatter libraries may nee
 
 
 ## Release Notes
-  * Added support for Sentinel-2 Level-1C products.
-  * Added view angles (similar to the solar angles) to the schema and output
-    XML file, in support of the Sentinel-2 products.
-  * Fixed a bug when using strdup to copy the HDF5 VIIRS filename to the
-    output XML filename, then blowing past the memory by changing the .h5
-    file extension to .xml.
-  * Fixed a bug in the MODIS support of obtaining the tile number from the file
-    name to populate the htile, vtile in the global XML file.
-  * Modified the angle band routines to detect if the angle bands have been
-    previously generated.  If so, then the bands are not regenerated.  This
-    is a fix for calling LaSRC followed by LaORCA and having two different
-    listings of the angle bands in the XML file.  When converting the ESPA
-    format to another format, both listings will attempt to be converted.  The
-    second listing could fail if remove source files is used for the conversion
-    because the files are removed after converting the first listing.
+  * Cleaned up some warning codes flagged after migrating to a newer system.
+  * Fixed a bug in parse_sentinel_metadata.c.  Prodtype is a character
+    pointer and not an array, therefore the pointer must be dereferenced
+    when used as an argument in sizeof.

--- a/raw_binary/common/espa_common.h
+++ b/raw_binary/common/espa_common.h
@@ -14,7 +14,7 @@ NOTES:
 #ifndef ESPA_COMMON_H_
 #define ESPA_COMMON_H_
 
-#define ESPA_COMMON_VERSION "1.18.0"
+#define ESPA_COMMON_VERSION "1.18.1"
 
 /* Set up default success/error defines */
 #define SUCCESS 0

--- a/raw_binary/common/espa_common.h
+++ b/raw_binary/common/espa_common.h
@@ -14,7 +14,7 @@ NOTES:
 #ifndef ESPA_COMMON_H_
 #define ESPA_COMMON_H_
 
-#define ESPA_COMMON_VERSION "1.18.1"
+#define ESPA_COMMON_VERSION "1.19.0"
 
 /* Set up default success/error defines */
 #define SUCCESS 0

--- a/raw_binary/format_conversion_libs/convert_espa_to_netcdf.c
+++ b/raw_binary/format_conversion_libs/convert_espa_to_netcdf.c
@@ -638,7 +638,6 @@ int create_netcdf_metadata
     int x_varid;                  /* x coordinate variable ID */
     int y_varid;                  /* y coordinate variable ID */
     int dimids[2];                /* array for the dimension IDs */
-    int dims[2];                  /* array for dimension sizes; only 2D prods */
     float *xdims = NULL;          /* coordinate values for the x-dimension */
     float *ydims = NULL;          /* coordinate values for the y-dimension */
     int x;                        /* loop index */
@@ -690,8 +689,6 @@ int create_netcdf_metadata
         /* Define the dimensions for this band */
         nlines = xml_metadata->band[i].nlines;
         nsamps = xml_metadata->band[i].nsamps;
-        dims[0] = nlines;
-        dims[1] = nsamps;
 
         /* Determine the NetCDF data type */
         switch (xml_metadata->band[i].data_type)

--- a/raw_binary/format_conversion_libs/convert_sentinel_to_espa.c
+++ b/raw_binary/format_conversion_libs/convert_sentinel_to_espa.c
@@ -309,7 +309,6 @@ int convert_sentinel_to_espa
         bmeta = &xml_metadata.band[i];
         strcpy (bmeta->product, "MSIL1C");
         strcpy (bmeta->name, sentinel_bands[i]);
-        strcpy (bmeta->short_name, "S2MSI1C");
         strcpy (bmeta->category, "image");
         bmeta->data_type = ESPA_UINT16;
         bmeta->fill_value = 0;

--- a/raw_binary/format_conversion_libs/convert_sentinel_to_espa.c
+++ b/raw_binary/format_conversion_libs/convert_sentinel_to_espa.c
@@ -309,6 +309,7 @@ int convert_sentinel_to_espa
         bmeta = &xml_metadata.band[i];
         strcpy (bmeta->product, "MSIL1C");
         strcpy (bmeta->name, sentinel_bands[i]);
+        strcpy (bmeta->short_name, "S2MSI1C");
         strcpy (bmeta->category, "image");
         bmeta->data_type = ESPA_UINT16;
         bmeta->fill_value = 0;
@@ -321,8 +322,10 @@ int convert_sentinel_to_espa
             sentinel_band_nums[i]);
 
         /* Sentinel XML files don't indicate the application used to process
-           the original image files, so set to "not available" */
-        strcpy (bmeta->app_version, "not available");
+           the original image files, so instead we will use the name of the
+           current application used for conversion. */
+        sprintf (bmeta->app_version, "convert_sentinel_to_espa_%s",
+            ESPA_COMMON_VERSION);
     }
 
     /* Rename the current Sentinel JP2 bands to a new filename (using the

--- a/raw_binary/io_libs/parse_sentinel_metadata.c
+++ b/raw_binary/io_libs/parse_sentinel_metadata.c
@@ -1173,7 +1173,7 @@ int parse_sentinel_product_xml_into_struct
 
                 /* Copy the content of the child node into the value for this
                    field */
-                count = snprintf (prodtype, sizeof (prodtype), "%s",
+                count = snprintf (prodtype, sizeof (*prodtype), "%s",
                     (const char *) child_node->content);
                 if (count < 0 || count >= sizeof (prodtype))
                 {

--- a/raw_binary/io_libs/parse_sentinel_metadata.c
+++ b/raw_binary/io_libs/parse_sentinel_metadata.c
@@ -1173,7 +1173,7 @@ int parse_sentinel_product_xml_into_struct
 
                 /* Copy the content of the child node into the value for this
                    field */
-                count = snprintf (prodtype, sizeof (*prodtype), "%s",
+                count = snprintf (prodtype, STR_SIZE, "%s",
                     (const char *) child_node->content);
                 if (count < 0 || count >= sizeof (prodtype))
                 {

--- a/raw_binary/land_water_mask_libs/ias_geo_handle_180.c
+++ b/raw_binary/land_water_mask_libs/ias_geo_handle_180.c
@@ -254,7 +254,6 @@ static void add_once_around_to_dms
     double easy_soln; /* simple approach */
 
     double angle;  /* used in calculating tdeg, tmin, and tsec */
-    int status;
 
     /* First, we try a simple approach in which we simply add 360 degrees to
        the input value.  If we didn't cross zero, then we are done; that will
@@ -268,9 +267,9 @@ static void add_once_around_to_dms
         return;
     }
 
-    status = ias_geo_convert_dms2deg(*lon, &angle, "DEGREES");
+    ias_geo_convert_dms2deg(*lon, &angle, "DEGREES");
     angle += determine_once_around(DEGREE);
-    status = ias_geo_convert_deg2dms(angle, lon, "DEGREES");
+    ias_geo_convert_deg2dms(angle, lon, "DEGREES");
     
 }
 

--- a/raw_binary/per_pixel_angles_libs/l8_ias_lib/lablib3.c
+++ b/raw_binary/per_pixel_angles_libs/l8_ias_lib/lablib3.c
@@ -4291,7 +4291,6 @@ short OdlValidElement (char *text, char *message_fname,
     char *message = NULL;
     char element_prompt[TB_MAXLINE + 1];
     char *save_units = 0;
-    char *first_blank = {NULL};
     char *first_char = {NULL};
     char *last_char = {NULL};
     char *units_start = {NULL};
@@ -4307,7 +4306,6 @@ short OdlValidElement (char *text, char *message_fname,
 
     single_quote = (char *) strchr(text+1, (int) '\'');
     double_quote = (char *) strchr(text+1, (int) '"');
-    first_blank  = (char *) strchr(text+1, (int) ' ');
     first_char = text;
     last_char = (char *) LastChar(text);
 
@@ -5844,12 +5842,12 @@ char *OdlTempFname()
 {
     FILE *fptr = {NULL};
     char *fname = {NULL};
-    char temp_str  [TB_MAXPATH + TB_MAXFNAME];
     char base_name [TB_MAXPATH + TB_MAXFNAME];
 
     (void)strcpy(base_name, "tmp.tmp");
 
 #ifdef SUN_UNIX
+    char temp_str  [TB_MAXPATH + TB_MAXFNAME];
     (void)tmpnam(temp_str);
     (void)strcpy( base_name, temp_str);  /* Bug fix 11/2/94 SM                     */
                                    /* Was:    (void)sprintf(base_name, "~/%s.tmp", */
@@ -5857,11 +5855,13 @@ char *OdlTempFname()
 #endif
 
 #if (defined( VAX) || defined( ALPHA_VMS))
+    char temp_str  [TB_MAXPATH + TB_MAXFNAME];
     (void)tmpnam(temp_str);
     (void)sprintf(base_name, "sys$login:%s.tmp", temp_str);
 #endif
 
 #ifdef MAC_THINK
+    char temp_str  [TB_MAXPATH + TB_MAXFNAME];
     (void)tmpnam(temp_str);
     (void)sprintf(base_name, "%s.tmp", temp_str);
 #endif

--- a/raw_binary/per_pixel_angles_libs/landsat_angles.c
+++ b/raw_binary/per_pixel_angles_libs/landsat_angles.c
@@ -215,7 +215,6 @@ int landsat_per_pixel_angles
                                            status */
         int curr_tmp_percent;           /* Percentage for current line */
         double *height = NULL;          /* Height to evaluate */
-        angle_frame_TYPE frame;         /* Output image frame info. */
         size_t angle_size;              /* Number of elements in angle array */
 
         /* Check if this band is in the user-specified list of bands to be
@@ -295,17 +294,6 @@ int landsat_per_pixel_angles
                 return ERROR;
             }
         }
-
-        /* Establish the output image file frame */
-        frame.band_number =
-            xxx_get_user_band(metadata.band_metadata[band_index].band_number);
-        frame.num_lines = num_lines;
-        frame.num_samps = num_samps;
-        frame.projection.code = metadata.projection.code;
-        frame.projection.zone = metadata.projection.zone;
-        frame.pixel_size = metadata.band_metadata[band_index].pixel_size;
-        frame.ul_corner.x = metadata.corners.upleft.x;
-        frame.ul_corner.y = metadata.corners.upleft.y;
 
         /* Loop through the L1T lines and samples */
         tmp_percent = 0;

--- a/raw_binary/per_pixel_angles_libs/landsat_ias_lib/lablib3.c
+++ b/raw_binary/per_pixel_angles_libs/landsat_ias_lib/lablib3.c
@@ -4247,7 +4247,6 @@ short OdlValidElement (char *text, char *message_fname,
     char *message = NULL;
     char element_prompt[TB_MAXLINE + 1];
     char *save_units = 0;
-    char *first_blank = {NULL};
     char *first_char = {NULL};
     char *last_char = {NULL};
     char *units_start = {NULL};
@@ -4263,7 +4262,6 @@ short OdlValidElement (char *text, char *message_fname,
 
     single_quote = (char *) strchr(text+1, (int) '\'');
     double_quote = (char *) strchr(text+1, (int) '"');
-    first_blank  = (char *) strchr(text+1, (int) ' ');
     first_char = text;
     last_char = (char *) LastChar(text);
 
@@ -5782,12 +5780,12 @@ char *OdlTempFname()
 {
     FILE *fptr = {NULL};
     char *fname = {NULL};
-    char temp_str  [TB_MAXPATH + TB_MAXFNAME];
     char base_name [TB_MAXPATH + TB_MAXFNAME];
 
     (void)strcpy(base_name, "tmp.tmp");
 
 #ifdef SUN_UNIX
+    char temp_str  [TB_MAXPATH + TB_MAXFNAME];
     (void)tmpnam(temp_str);
     (void)strcpy( base_name, temp_str);  /* Bug fix 11/2/94 SM                     */
                                    /* Was:    (void)sprintf(base_name, "~/%s.tmp", */
@@ -5795,11 +5793,13 @@ char *OdlTempFname()
 #endif
 
 #if (defined( VAX) || defined( ALPHA_VMS))
+    char temp_str  [TB_MAXPATH + TB_MAXFNAME];
     (void)tmpnam(temp_str);
     (void)sprintf(base_name, "sys$login:%s.tmp", temp_str);
 #endif
 
 #ifdef MAC_THINK
+    char temp_str  [TB_MAXPATH + TB_MAXFNAME];
     (void)tmpnam(temp_str);
     (void)sprintf(base_name, "%s.tmp", temp_str);
 #endif

--- a/raw_binary/tools/create_angle_bands.c
+++ b/raw_binary/tools/create_angle_bands.c
@@ -225,7 +225,6 @@ int main (int argc, char** argv)
     bool process_l7 = false;     /* are we processing L7 vs. L4-5 or L8 */
     bool process_l45 = false;    /* are we processing L4-5 vs. L7 or L8 */
     int i;                       /* looping variable for bands */
-    int count;                   /* number of chars copied in snprintf */
     int curr_band;               /* current input band number */
     int curr_bndx;               /* index of current input band */
     int nbands;                  /* number of input bands to be read */
@@ -622,7 +621,7 @@ int main (int argc, char** argv)
             {
                 case (SOLAR_ZEN):  /* solar zenith */
                     /* Determine the output file for the solar zenith band */
-                    count = snprintf (tmpfile, sizeof (tmpfile),
+                    snprintf (tmpfile, sizeof (tmpfile),
                         "%s_avg_solar_zenith.img", outfile);
                     sprintf (out_bmeta->name, "avg_solar_zenith_band");
                     strncpy (tmpstr, bmeta[0].short_name, 4);
@@ -634,7 +633,7 @@ int main (int argc, char** argv)
 
                 case (SOLAR_AZ):  /* solar zenith */
                     /* Determine the output file for the solar azimuth band */
-                    count = snprintf (tmpfile, sizeof (tmpfile),
+                    snprintf (tmpfile, sizeof (tmpfile),
                         "%s_avg_solar_azimuth.img", outfile);
                     sprintf (out_bmeta->name, "avg_solar_azimuth_band");
                     strncpy (tmpstr, bmeta[0].short_name, 4);
@@ -646,7 +645,7 @@ int main (int argc, char** argv)
 
                 case (SENSOR_ZEN):  /* sensor zenith */
                     /* Determine the output file for the sensor zenith band */
-                    count = snprintf (tmpfile, sizeof (tmpfile),
+                    snprintf (tmpfile, sizeof (tmpfile),
                         "%s_avg_sensor_zenith.img", outfile);
                     sprintf (out_bmeta->name, "avg_sensor_zenith_band");
                     strncpy (tmpstr, bmeta[0].short_name, 4);
@@ -658,7 +657,7 @@ int main (int argc, char** argv)
 
                 case (SENSOR_AZ):  /* sensor azimuth */
                     /* Determine the output file for the sensor azimuth band */
-                    count = snprintf (tmpfile, sizeof (tmpfile),
+                    snprintf (tmpfile, sizeof (tmpfile),
                         "%s_avg_sensor_azimuth.img", outfile);
                     sprintf (out_bmeta->name, "avg_sensor_azimuth_band");
                     strncpy (tmpstr, bmeta[0].short_name, 4);

--- a/raw_binary/tools/create_landsat_angle_bands.c
+++ b/raw_binary/tools/create_landsat_angle_bands.c
@@ -321,7 +321,7 @@ int main (int argc, char** argv)
         band_indx = etm_band_indx;
         strcpy (band_list, etm_list);
     }
-    else
+    else if (process_l45)
     {
         landsat_bands = tm_bands;
         landsat_nbands = tm_nbands;


### PR DESCRIPTION
There is a bug fix in here for the short_name in the XML file of the Sentinel products.  The bug hasn't popped up in processing, but it's there.  Also, cleaned up some unused variables and other warning statements that were previously ignored because they were in code provided by the Landsat team.